### PR TITLE
fix: Moved dev dependencies to `dev_deps.ts`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/.deno
             ~/.cache/deno
-          key: ${{ runner.os }}-deno-${{ hashFiles('**/deps.ts') }}
+          key: ${{ runner.os }}-deno-${{ hashFiles('**/*deps.ts') }}
       - name: Run tests
         run: deno task test --doc
   
@@ -51,7 +51,7 @@ jobs:
           path: |
             ~/.deno
             ~/.cache/deno
-          key: ${{ runner.os }}-deno-${{ hashFiles('**/deps.ts') }}
+          key: ${{ runner.os }}-deno-${{ hashFiles('**/*deps.ts') }}
       - name: Run tests
         run: deno task coverage
       - name: Upload lcov file

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -16,7 +16,7 @@ jobs:
           deno-version: 1.23.3
       - name: Update dependencies
         run: |
-          deno run -A https://deno.land/x/udd@0.7.4/main.ts deps.ts
+          deno run -A https://deno.land/x/udd@0.7.4/main.ts *deps.ts
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         id: pr

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,3 @@
-// Standard library
-export * as asserts from "https://deno.land/std@0.152.0/testing/asserts.ts#^";
 export * as yaml from "https://deno.land/std@0.152.0/encoding/yaml.ts#^";
 export * as path from "https://deno.land/std@0.152.0/path/mod.ts#^";
 export * as flags from "https://deno.land/std@0.152.0/flags/mod.ts#^";

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,0 +1,1 @@
+export * as asserts from "https://deno.land/std@0.151.0/testing/asserts.ts#^";

--- a/test/auto.test.ts
+++ b/test/auto.test.ts
@@ -1,4 +1,4 @@
-import { asserts } from "../deps.ts";
+import { asserts } from "../dev_deps.ts";
 import { auto } from "../mod.ts";
 
 const RESOURCES_FOLDER = "test/resources";

--- a/test/extractor/commandline.test.ts
+++ b/test/extractor/commandline.test.ts
@@ -1,4 +1,4 @@
-import { asserts } from "../../deps.ts";
+import { asserts } from "../../dev_deps.ts";
 import { CommandLineExtractor } from "../../mod.ts";
 
 Deno.test("Empty argument list creates an empty object", async () => {

--- a/test/extractor/default.test.ts
+++ b/test/extractor/default.test.ts
@@ -1,5 +1,5 @@
 import { DefaultExtractor } from "../../mod.ts";
-import { asserts } from "../../deps.ts";
+import { asserts } from "../../dev_deps.ts";
 
 Deno.test("Extract returns the same object", async () => {
   const expected = { hello: "world", this: 10 };

--- a/test/extractor/env.test.ts
+++ b/test/extractor/env.test.ts
@@ -1,4 +1,4 @@
-import { asserts } from "../../deps.ts";
+import { asserts } from "../../dev_deps.ts";
 import { EnvExtractor } from "../../mod.ts";
 
 Deno.test(

--- a/test/extractor/index.test.ts
+++ b/test/extractor/index.test.ts
@@ -1,4 +1,4 @@
-import { asserts } from "../../deps.ts";
+import { asserts } from "../../dev_deps.ts";
 import { JsonExtractor, toFileExtractor, YamlExtractor } from "../../mod.ts";
 
 Deno.test("toExtractor generates a Yaml extractor for .yml files", () => {

--- a/test/extractor/json.test.ts
+++ b/test/extractor/json.test.ts
@@ -1,4 +1,4 @@
-import { asserts } from "../../deps.ts";
+import { asserts } from "../../dev_deps.ts";
 import { JsonExtractor } from "../../mod.ts";
 
 const RESOURCES_FOLDER = "test/resources";

--- a/test/extractor/yaml.test.ts
+++ b/test/extractor/yaml.test.ts
@@ -1,4 +1,4 @@
-import { asserts } from "../../deps.ts";
+import { asserts } from "../../dev_deps.ts";
 import { YamlExtractor } from "../../mod.ts";
 
 const RESOURCES_FOLDER = "test/resources";

--- a/test/getConfig.test.ts
+++ b/test/getConfig.test.ts
@@ -1,4 +1,4 @@
-import { asserts } from "../deps.ts";
+import { asserts } from "../dev_deps.ts";
 import { DefaultExtractor, getConfig } from "../mod.ts";
 
 Deno.test("Empty extractor list returns empty object", async () => {


### PR DESCRIPTION
Dev dependencies now live on a separate file, meaning you don't need to download them for production